### PR TITLE
extend documentation of touch()

### DIFF
--- a/base/file.jl
+++ b/base/file.jl
@@ -391,6 +391,7 @@ end
     touch(path::AbstractString)
 
 Update the last-modified timestamp on a file to the current time.
+If the file does not exists a new file is created.
 Return `path`.
 
 # Examples


### PR DESCRIPTION
The documentation of `touch()` is missing the information that it creates the file if it does not already exists. 
That behaviour might be clear for most linux users but since at least I explicitly searched for that information in the documentation I thought it would be nice to spare the next me the 30 seconds to try `touch("thisfileshouldnotexistyet")`.
